### PR TITLE
Add auto-detection of paired-end FASTQ naming patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,19 @@ snakemake --profile ../profile/slurm/ --config reads=/path/to/reads outdir=/path
 ## Configuration Options
 
 ### Required Parameters
-- `reads`: Directory containing paired-end FASTQ files (suffixes: `_1.fastq.gz`, `_2.fastq.gz`)
+- `reads`: Directory containing paired-end FASTQ files
 - `outdir`: Output directory for all results
 
-### Optional Parameters
-- `fastq_names_1`: R1 file pattern (default: `{sample}_1.fastq.gz`)
-- `fastq_names_2`: R2 file pattern (default: `{sample}_2.fastq.gz`)
+### Input File Detection
+The pipeline automatically detects common FASTQ naming patterns:
+- `{sample}_1.fastq.gz` / `{sample}_2.fastq.gz`
+- `{sample}_R1.fastq.gz` / `{sample}_R2.fastq.gz`
+- `{sample}_R1_001.fastq.gz` / `{sample}_R2_001.fastq.gz` (Illumina default)
+- Also supports `.fq.gz`, `.fastq`, and `.fq` extensions
+
+For non-standard naming, specify patterns explicitly:
+- `fastq_names_1`: R1 file pattern (e.g., `{sample}_R1_001.fastq.gz`)
+- `fastq_names_2`: R2 file pattern (e.g., `{sample}_R2_001.fastq.gz`)
 - `fastp_min_sequence_length`: Minimum read length after trimming (default: 120)
 - `taxonomy_scope`: Taxonomy analysis scope - `"prophage_only"` or `"all_contigs"` (default: `"prophage_only"`)
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,8 +1,12 @@
 reads: "reads"
 outdir: "out"
 
-fastq_names_1: "{sample}_1.fastq.gz"
-fastq_names_2: "{sample}_2.fastq.gz"
+# FASTQ naming patterns - set to "auto" to auto-detect common patterns
+# (_1/_2, _R1/_R2, .fastq.gz/.fq.gz variants), or specify explicitly like:
+# fastq_names_1: "{sample}_R1_001.fastq.gz"
+# fastq_names_2: "{sample}_R2_001.fastq.gz"
+fastq_names_1: "auto"
+fastq_names_2: "auto"
 fastp_min_sequence_length: 120 
 
 human_ref: "/ref/sahlab/data/GRCh38.fna.gz"

--- a/prophage_101325.drawio
+++ b/prophage_101325.drawio
@@ -1,0 +1,245 @@
+<mxfile host="app.diagrams.net" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36" version="28.2.5">
+  <diagram name="Page-1" id="3_9651rIJdXSfUgyBS7o">
+    <mxGraphModel dx="1900" dy="676" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <mxCell id="3NcZRav7OvsKikojFnIu-1" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#f5f5f5;strokeColor=#666666;strokeWidth=0;fontColor=#333333;" vertex="1" parent="1">
+          <mxGeometry x="-790" y="50" width="930" height="580" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-2" value="" style="rounded=0;whiteSpace=wrap;html=1;strokeWidth=0;fillColor=#e1d5e7;strokeColor=#9673a6;" vertex="1" parent="1">
+          <mxGeometry x="-360" y="50" width="500" height="400" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-3" value="" style="rounded=0;whiteSpace=wrap;html=1;strokeWidth=0;fillColor=#d5e8d4;strokeColor=#82b366;" vertex="1" parent="1">
+          <mxGeometry x="-580" y="50" width="220" height="400" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-4" value="" style="rounded=0;whiteSpace=wrap;html=1;strokeWidth=0;fillColor=#ffe6cc;strokeColor=#d79b00;" vertex="1" parent="1">
+          <mxGeometry x="-790" y="50" width="210" height="400" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-5" style="edgeStyle=orthogonalEdgeStyle;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="3NcZRav7OvsKikojFnIu-6" target="3NcZRav7OvsKikojFnIu-13">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-6" value="Raw reads" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;glass=0;strokeWidth=1;shadow=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" vertex="1" parent="1">
+          <mxGeometry x="-730" y="105" width="90" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-7" style="edgeStyle=orthogonalEdgeStyle;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" edge="1" parent="1" source="3NcZRav7OvsKikojFnIu-9" target="3NcZRav7OvsKikojFnIu-17">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-8" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;curved=1;" edge="1" parent="1" source="3NcZRav7OvsKikojFnIu-9" target="3NcZRav7OvsKikojFnIu-58">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-9" value="Host-removed reads" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;glass=0;strokeWidth=1;shadow=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" vertex="1" parent="1">
+          <mxGeometry x="-730" y="375" width="90" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-10" style="edgeStyle=orthogonalEdgeStyle;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="3NcZRav7OvsKikojFnIu-11" target="3NcZRav7OvsKikojFnIu-35">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-11" value="Unbinned contigs" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;glass=0;strokeWidth=1;shadow=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" vertex="1" parent="1">
+          <mxGeometry x="-20" y="210" width="90" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-12" style="edgeStyle=orthogonalEdgeStyle;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="3NcZRav7OvsKikojFnIu-13" target="3NcZRav7OvsKikojFnIu-9">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-13" value="Trimmed reads" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;glass=0;strokeWidth=1;shadow=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" vertex="1" parent="1">
+          <mxGeometry x="-730" y="240" width="90" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-14" value="&lt;b&gt;Minimap2&lt;/b&gt; to remove reads mapping to host genome" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="-770" y="293" width="170" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-15" value="&lt;b&gt;Fastp&lt;/b&gt; for adapter removal" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="-770" y="158" width="170" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-16" style="edgeStyle=orthogonalEdgeStyle;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" edge="1" parent="1" source="3NcZRav7OvsKikojFnIu-17" target="3NcZRav7OvsKikojFnIu-26">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-17" value="&lt;b&gt;MEGAHIT&lt;/b&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="-513" y="305" width="100" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-18" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;curved=1;" edge="1" parent="1" source="3NcZRav7OvsKikojFnIu-19" target="3NcZRav7OvsKikojFnIu-33">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-19" value="&lt;b&gt;CONCOCT&lt;/b&gt;&lt;span style=&quot;color: rgba(0, 0, 0, 0); font-family: monospace; font-size: 0px; text-align: start; text-wrap: nowrap;&quot;&gt;%3CmxGraphModel%3E%3Croot%3E%3CmxCell%20id%3D%220%22%2F%3E%3CmxCell%20id%3D%221%22%20parent%3D%220%22%2F%3E%3CmxCell%20id%3D%222%22%20value%3D%22remove%20contigs%20%26amp%3Blt%3B%201000bp%22%20style%3D%22ellipse%3BwhiteSpace%3Dwrap%3Bhtml%3D1%3BfillColor%3D%23fff2cc%3BstrokeColor%3D%23d6b656%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%3CmxGeometry%20x%3D%2270%22%20y%3D%22400%22%20width%3D%22100%22%20height%3D%2260%22%20as%3D%22geometry%22%2F%3E%3C%2FmxCell%3E%3C%2Froot%3E%3C%2FmxGraphModel%3E&lt;/span&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="-320" y="55" width="100" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-20" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="3NcZRav7OvsKikojFnIu-21" target="3NcZRav7OvsKikojFnIu-69">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-21" value="&lt;b&gt;checkM&lt;/b&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="-110" y="470" width="103" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-22" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="3NcZRav7OvsKikojFnIu-23" target="3NcZRav7OvsKikojFnIu-33">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-23" value="&lt;b&gt;MaxBin2&lt;/b&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="-320" y="115" width="100" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-24" style="edgeStyle=orthogonalEdgeStyle;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" edge="1" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="-490" y="345" as="sourcePoint" />
+            <mxPoint x="-490" y="345" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-25" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" edge="1" parent="1" source="3NcZRav7OvsKikojFnIu-26" target="3NcZRav7OvsKikojFnIu-30">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-26" value="Contigs" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;glass=0;strokeWidth=1;shadow=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" vertex="1" parent="1">
+          <mxGeometry x="-508" y="250" width="90" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-27" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;curved=1;" edge="1" parent="1" source="3NcZRav7OvsKikojFnIu-30" target="3NcZRav7OvsKikojFnIu-23">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-28" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;curved=1;" edge="1" parent="1" source="3NcZRav7OvsKikojFnIu-30" target="3NcZRav7OvsKikojFnIu-19">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-29" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;curved=1;" edge="1" parent="1" source="3NcZRav7OvsKikojFnIu-30" target="3NcZRav7OvsKikojFnIu-38">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-30" value="Contigs &amp;gt;1000bp" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;glass=0;strokeWidth=1;shadow=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" vertex="1" parent="1">
+          <mxGeometry x="-508" y="105" width="90" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-31" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;curved=1;" edge="1" parent="1" source="3NcZRav7OvsKikojFnIu-33" target="3NcZRav7OvsKikojFnIu-43">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-32" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;curved=1;" edge="1" parent="1" source="3NcZRav7OvsKikojFnIu-33" target="3NcZRav7OvsKikojFnIu-11">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-33" value="&lt;b&gt;DAS Tool&lt;/b&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="-80" y="115" width="100" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-34" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;curved=1;" edge="1" parent="1" source="3NcZRav7OvsKikojFnIu-35" target="3NcZRav7OvsKikojFnIu-64">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-35" value="Unbinned contigs &amp;gt;4000bp" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;glass=0;strokeWidth=1;shadow=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" vertex="1" parent="1">
+          <mxGeometry x="-25" y="345" width="100" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-36" value="remove contigs &amp;lt; 4000bp" style="ellipse;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;" vertex="1" parent="1">
+          <mxGeometry x="-20" y="270" width="90" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-37" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;curved=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="3NcZRav7OvsKikojFnIu-38" target="3NcZRav7OvsKikojFnIu-33">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="-150" y="190" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-38" value="&lt;b&gt;MetaBat2&lt;/b&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="-320" y="175" width="100" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-39" value="Bins" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;glass=0;strokeWidth=1;shadow=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" vertex="1" parent="1">
+          <mxGeometry x="-200" y="65" width="30" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-40" value="Bins" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;glass=0;strokeWidth=1;shadow=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" vertex="1" parent="1">
+          <mxGeometry x="-200" y="125" width="30" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-41" value="Bins" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;glass=0;strokeWidth=1;shadow=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" vertex="1" parent="1">
+          <mxGeometry x="-200" y="185" width="30" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-42" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;curved=1;" edge="1" parent="1" source="3NcZRav7OvsKikojFnIu-43" target="3NcZRav7OvsKikojFnIu-64">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-43" value="Non-redundant set of bins" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;glass=0;strokeWidth=1;shadow=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" vertex="1" parent="1">
+          <mxGeometry x="-130" y="210" width="90" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-44" value="Preprocessing" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontStyle=1;fontSize=15;fontFamily=Helvetica;textShadow=1;" vertex="1" parent="1">
+          <mxGeometry x="-790" y="50" width="120" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-45" value="Assembly" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontStyle=1;fontSize=15;textShadow=1;" vertex="1" parent="1">
+          <mxGeometry x="-510" y="50" width="90" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-46" value="Binning" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontStyle=1;fontSize=15;textShadow=1;" vertex="1" parent="1">
+          <mxGeometry x="70" y="50" width="70" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-47" style="edgeStyle=orthogonalEdgeStyle;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="3NcZRav7OvsKikojFnIu-48" target="3NcZRav7OvsKikojFnIu-52">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-48" value="&lt;b&gt;geNomad&lt;/b&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="-390" y="470" width="100" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-49" style="edgeStyle=orthogonalEdgeStyle;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="3NcZRav7OvsKikojFnIu-50" target="3NcZRav7OvsKikojFnIu-52">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-50" value="&lt;b&gt;phiSpy&lt;/b&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="-250" y="470" width="100" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-51" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;curved=1;" edge="1" parent="1" source="3NcZRav7OvsKikojFnIu-52" target="3NcZRav7OvsKikojFnIu-67">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-52" value="Predicted prophages" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;glass=0;strokeWidth=1;shadow=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" vertex="1" parent="1">
+          <mxGeometry x="-315" y="575" width="90" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-53" value="" style="ellipse;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="-135" y="540" width="5" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-54" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="3NcZRav7OvsKikojFnIu-55" target="3NcZRav7OvsKikojFnIu-65">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-55" value="&lt;b&gt;CAT&lt;/b&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="-550" y="470" width="100" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-56" value="remove contigs &amp;lt; 1000bp" style="ellipse;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;" vertex="1" parent="1">
+          <mxGeometry x="-508" y="175" width="90" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-57" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="3NcZRav7OvsKikojFnIu-58" target="3NcZRav7OvsKikojFnIu-68">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-58" value="&lt;b&gt;CoverM&lt;/b&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="-710" y="470" width="100" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-59" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;curved=1;" edge="1" parent="1" source="3NcZRav7OvsKikojFnIu-64" target="3NcZRav7OvsKikojFnIu-55">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="-270" y="450" />
+              <mxPoint x="-500" y="450" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-60" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;curved=1;" edge="1" parent="1" source="3NcZRav7OvsKikojFnIu-64" target="3NcZRav7OvsKikojFnIu-21">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-61" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;curved=1;" edge="1" parent="1" source="3NcZRav7OvsKikojFnIu-64" target="3NcZRav7OvsKikojFnIu-58">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="-270" y="440" />
+              <mxPoint x="-660" y="440" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-62" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;curved=1;" edge="1" parent="1" source="3NcZRav7OvsKikojFnIu-64" target="3NcZRav7OvsKikojFnIu-48">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="-270" y="450" />
+              <mxPoint x="-340" y="450" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-63" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;curved=1;" edge="1" parent="1" source="3NcZRav7OvsKikojFnIu-64" target="3NcZRav7OvsKikojFnIu-50">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="-270" y="450" />
+              <mxPoint x="-200" y="450" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-64" value="Bins and contigs" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;glass=0;strokeWidth=1;shadow=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" vertex="1" parent="1">
+          <mxGeometry x="-315" y="345" width="90" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-65" value="Taxonomy prediction" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;glass=0;strokeWidth=1;shadow=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" vertex="1" parent="1">
+          <mxGeometry x="-545" y="575" width="90" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-66" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="3NcZRav7OvsKikojFnIu-67" target="3NcZRav7OvsKikojFnIu-70">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-67" value="&lt;b&gt;checkV&lt;/b&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="-110" y="570" width="103" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-68" value="Read coverage" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;glass=0;strokeWidth=1;shadow=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" vertex="1" parent="1">
+          <mxGeometry x="-705" y="575" width="90" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-69" value="Bacterial genome quality scores" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;glass=0;strokeWidth=1;shadow=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" vertex="1" parent="1">
+          <mxGeometry x="20" y="480" width="100" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="3NcZRav7OvsKikojFnIu-70" value="Prophage quality scores" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;glass=0;strokeWidth=1;shadow=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" vertex="1" parent="1">
+          <mxGeometry x="20" y="580" width="100" height="30" as="geometry" />
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/prophage_updated_workflow.drawio
+++ b/prophage_updated_workflow.drawio
@@ -1,0 +1,408 @@
+<mxfile host="app.diagrams.net" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36" version="28.2.5">
+  <diagram name="Page-1" id="3_9651rIJdXSfUgyBS7o">
+    <mxGraphModel dx="2200" dy="800" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1400" pageHeight="1100" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+
+        <!-- Background sections -->
+        <mxCell id="bg-all" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#f5f5f5;strokeColor=#666666;strokeWidth=0;fontColor=#333333;" vertex="1" parent="1">
+          <mxGeometry x="-790" y="50" width="2150" height="950" as="geometry" />
+        </mxCell>
+
+        <!-- Preprocessing section (orange) -->
+        <mxCell id="bg-preprocessing" value="" style="rounded=0;whiteSpace=wrap;html=1;strokeWidth=0;fillColor=#ffe6cc;strokeColor=#d79b00;" vertex="1" parent="1">
+          <mxGeometry x="-790" y="50" width="210" height="400" as="geometry" />
+        </mxCell>
+
+        <!-- Assembly section (green) -->
+        <mxCell id="bg-assembly" value="" style="rounded=0;whiteSpace=wrap;html=1;strokeWidth=0;fillColor=#d5e8d4;strokeColor=#82b366;" vertex="1" parent="1">
+          <mxGeometry x="-580" y="50" width="220" height="400" as="geometry" />
+        </mxCell>
+
+        <!-- Binning section (purple) -->
+        <mxCell id="bg-binning" value="" style="rounded=0;whiteSpace=wrap;html=1;strokeWidth=0;fillColor=#e1d5e7;strokeColor=#9673a6;" vertex="1" parent="1">
+          <mxGeometry x="-360" y="50" width="280" height="400" as="geometry" />
+        </mxCell>
+
+        <!-- MAG Analysis section (light blue) -->
+        <mxCell id="bg-mag-analysis" value="" style="rounded=0;whiteSpace=wrap;html=1;strokeWidth=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" vertex="1" parent="1">
+          <mxGeometry x="-80" y="50" width="420" height="550" as="geometry" />
+        </mxCell>
+
+        <!-- Unbinned Analysis section (light yellow) -->
+        <mxCell id="bg-unbinned-analysis" value="" style="rounded=0;whiteSpace=wrap;html=1;strokeWidth=0;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="340" y="50" width="420" height="550" as="geometry" />
+        </mxCell>
+
+        <!-- Quality & Reporting section (light green) -->
+        <mxCell id="bg-quality" value="" style="rounded=0;whiteSpace=wrap;html=1;strokeWidth=0;fillColor=#d5e8d4;strokeColor=#82b366;" vertex="1" parent="1">
+          <mxGeometry x="760" y="50" width="600" height="550" as="geometry" />
+        </mxCell>
+
+        <!-- Section Headers -->
+        <mxCell id="header-preprocessing" value="Preprocessing" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontStyle=1;fontSize=15;" vertex="1" parent="1">
+          <mxGeometry x="-760" y="60" width="120" height="30" as="geometry" />
+        </mxCell>
+
+        <mxCell id="header-assembly" value="Assembly" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontStyle=1;fontSize=15;" vertex="1" parent="1">
+          <mxGeometry x="-510" y="60" width="90" height="30" as="geometry" />
+        </mxCell>
+
+        <mxCell id="header-binning" value="Binning" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontStyle=1;fontSize=15;" vertex="1" parent="1">
+          <mxGeometry x="-255" y="60" width="70" height="30" as="geometry" />
+        </mxCell>
+
+        <mxCell id="header-mag" value="MAG Analysis" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontStyle=1;fontSize=15;" vertex="1" parent="1">
+          <mxGeometry x="70" y="60" width="120" height="30" as="geometry" />
+        </mxCell>
+
+        <mxCell id="header-unbinned" value="Unbinned Contig Analysis" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontStyle=1;fontSize=15;" vertex="1" parent="1">
+          <mxGeometry x="450" y="60" width="200" height="30" as="geometry" />
+        </mxCell>
+
+        <mxCell id="header-quality" value="Quality Control &amp; Reporting" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontStyle=1;fontSize=15;" vertex="1" parent="1">
+          <mxGeometry x="960" y="60" width="210" height="30" as="geometry" />
+        </mxCell>
+
+        <!-- PREPROCESSING SECTION -->
+        <mxCell id="raw-reads" value="Raw reads" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;strokeWidth=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="1">
+          <mxGeometry x="-730" y="105" width="90" height="30" as="geometry" />
+        </mxCell>
+
+        <mxCell id="fastp" value="&lt;b&gt;Fastp&lt;/b&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="-720" y="155" width="70" height="50" as="geometry" />
+        </mxCell>
+
+        <mxCell id="trimmed-reads" value="Trimmed reads" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;strokeWidth=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="1">
+          <mxGeometry x="-730" y="225" width="90" height="30" as="geometry" />
+        </mxCell>
+
+        <mxCell id="minimap2" value="&lt;b&gt;Minimap2&lt;/b&gt;&lt;br&gt;(host removal)" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="-730" y="275" width="90" height="60" as="geometry" />
+        </mxCell>
+
+        <mxCell id="hr-reads" value="Host-removed reads" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;strokeWidth=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="1">
+          <mxGeometry x="-730" y="360" width="90" height="30" as="geometry" />
+        </mxCell>
+
+        <!-- ASSEMBLY SECTION -->
+        <mxCell id="megahit" value="&lt;b&gt;MEGAHIT&lt;/b&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="-513" y="290" width="100" height="50" as="geometry" />
+        </mxCell>
+
+        <mxCell id="contigs" value="Contigs" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;strokeWidth=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="1">
+          <mxGeometry x="-508" y="235" width="90" height="30" as="geometry" />
+        </mxCell>
+
+        <mxCell id="filter-1000" value="Filter &amp;gt;1000bp" style="ellipse;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="-508" y="160" width="90" height="50" as="geometry" />
+        </mxCell>
+
+        <mxCell id="contigs-1000" value="Contigs &amp;gt;1000bp" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;strokeWidth=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="1">
+          <mxGeometry x="-508" y="100" width="90" height="30" as="geometry" />
+        </mxCell>
+
+        <!-- BINNING SECTION -->
+        <mxCell id="concoct" value="&lt;b&gt;CONCOCT&lt;/b&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="-320" y="100" width="80" height="45" as="geometry" />
+        </mxCell>
+
+        <mxCell id="maxbin" value="&lt;b&gt;MaxBin2&lt;/b&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="-320" y="155" width="80" height="45" as="geometry" />
+        </mxCell>
+
+        <mxCell id="metabat" value="&lt;b&gt;MetaBAT2&lt;/b&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="-320" y="210" width="80" height="45" as="geometry" />
+        </mxCell>
+
+        <mxCell id="dastool" value="&lt;b&gt;DAS Tool&lt;/b&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="-180" y="160" width="80" height="50" as="geometry" />
+        </mxCell>
+
+        <mxCell id="bins" value="MAG Bins" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;strokeWidth=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="1">
+          <mxGeometry x="-165" y="250" width="50" height="30" as="geometry" />
+        </mxCell>
+
+        <mxCell id="unbinned" value="Unbinned contigs &amp;gt;4000bp" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;strokeWidth=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="1">
+          <mxGeometry x="-165" y="300" width="100" height="40" as="geometry" />
+        </mxCell>
+
+        <!-- MAG ANALYSIS SECTION -->
+        <mxCell id="bakta" value="&lt;b&gt;Bakta&lt;/b&gt;&lt;br&gt;(annotation)" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="-40" y="130" width="80" height="55" as="geometry" />
+        </mxCell>
+
+        <mxCell id="phispy-mag" value="&lt;b&gt;PhiSpy&lt;/b&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="-40" y="200" width="80" height="50" as="geometry" />
+        </mxCell>
+
+        <mxCell id="genomad-mag" value="&lt;b&gt;geNomad&lt;/b&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="60" y="150" width="80" height="50" as="geometry" />
+        </mxCell>
+
+        <mxCell id="merge-mag" value="Merge prophage predictions" style="ellipse;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="10" y="280" width="90" height="60" as="geometry" />
+        </mxCell>
+
+        <mxCell id="mag-prophages" value="MAG prophages" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;strokeWidth=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="1">
+          <mxGeometry x="5" y="370" width="100" height="30" as="geometry" />
+        </mxCell>
+
+        <mxCell id="gtdbtk" value="&lt;b&gt;GTDB-Tk&lt;/b&gt;&lt;br&gt;taxonomy" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="170" y="150" width="80" height="55" as="geometry" />
+        </mxCell>
+
+        <mxCell id="mag-taxonomy" value="MAG taxonomy" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;strokeWidth=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="1">
+          <mxGeometry x="160" y="230" width="100" height="30" as="geometry" />
+        </mxCell>
+
+        <!-- UNBINNED ANALYSIS SECTION -->
+        <mxCell id="genomad-unbinned" value="&lt;b&gt;geNomad&lt;/b&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="380" y="150" width="80" height="50" as="geometry" />
+        </mxCell>
+
+        <mxCell id="checkv-prophage-pred" value="&lt;b&gt;CheckV&lt;/b&gt;&lt;br&gt;(prophage pred)" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="480" y="150" width="80" height="55" as="geometry" />
+        </mxCell>
+
+        <mxCell id="merge-unbinned" value="Merge prophage predictions" style="ellipse;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="425" y="230" width="90" height="60" as="geometry" />
+        </mxCell>
+
+        <mxCell id="unbinned-prophages" value="Unbinned prophages" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;strokeWidth=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="1">
+          <mxGeometry x="420" y="320" width="100" height="30" as="geometry" />
+        </mxCell>
+
+        <mxCell id="free-phages" value="Free phages" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;strokeWidth=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="1">
+          <mxGeometry x="540" y="320" width="100" height="30" as="geometry" />
+        </mxCell>
+
+        <mxCell id="mask-prophages" value="Mask prophage regions" style="ellipse;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="580" y="150" width="90" height="55" as="geometry" />
+        </mxCell>
+
+        <mxCell id="mmseqs" value="&lt;b&gt;MMseqs&lt;/b&gt;&lt;br&gt;taxonomy" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="590" y="230" width="80" height="55" as="geometry" />
+        </mxCell>
+
+        <mxCell id="unbinned-taxonomy" value="Unbinned taxonomy" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;strokeWidth=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="1">
+          <mxGeometry x="580" y="380" width="100" height="30" as="geometry" />
+        </mxCell>
+
+        <!-- QUALITY & REPORTING SECTION -->
+        <mxCell id="checkm" value="&lt;b&gt;CheckM&lt;/b&gt;&lt;br&gt;(MAG quality)" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="800" y="130" width="90" height="60" as="geometry" />
+        </mxCell>
+
+        <mxCell id="checkv-mag" value="&lt;b&gt;CheckV&lt;/b&gt;&lt;br&gt;(MAG prophages)" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="920" y="130" width="90" height="60" as="geometry" />
+        </mxCell>
+
+        <mxCell id="checkv-unbinned" value="&lt;b&gt;CheckV&lt;/b&gt;&lt;br&gt;(unbinned prophages + free phages)" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="1040" y="130" width="100" height="65" as="geometry" />
+        </mxCell>
+
+        <mxCell id="coverm" value="&lt;b&gt;CoverM&lt;/b&gt;&lt;br&gt;(all bins)" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="1170" y="130" width="90" height="60" as="geometry" />
+        </mxCell>
+
+        <mxCell id="combine-results" value="Combine all results" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;" vertex="1" parent="1">
+          <mxGeometry x="980" y="240" width="120" height="40" as="geometry" />
+        </mxCell>
+
+        <mxCell id="final-table" value="Final prophage table with taxonomy" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;strokeWidth=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="1">
+          <mxGeometry x="960" y="320" width="160" height="40" as="geometry" />
+        </mxCell>
+
+        <mxCell id="summary-report" value="Multi-sample summary report" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;strokeWidth=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="1">
+          <mxGeometry x="960" y="390" width="160" height="40" as="geometry" />
+        </mxCell>
+
+        <!-- EDGES/CONNECTIONS -->
+        <!-- Preprocessing flow -->
+        <mxCell id="edge1" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="raw-reads" target="fastp">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge2" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="fastp" target="trimmed-reads">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge3" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="trimmed-reads" target="minimap2">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge4" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="minimap2" target="hr-reads">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- Assembly flow -->
+        <mxCell id="edge5" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;curved=1;" edge="1" parent="1" source="hr-reads" target="megahit">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge6" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" edge="1" parent="1" source="megahit" target="contigs">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge7" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" edge="1" parent="1" source="contigs" target="filter-1000">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge8" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" edge="1" parent="1" source="filter-1000" target="contigs-1000">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- Binning flow -->
+        <mxCell id="edge9" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;curved=1;" edge="1" parent="1" source="contigs-1000" target="concoct">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge10" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;curved=1;" edge="1" parent="1" source="contigs-1000" target="maxbin">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge11" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;curved=1;" edge="1" parent="1" source="contigs-1000" target="metabat">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge12" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.33;entryDx=0;entryDy=0;curved=1;entryPerimeter=0;" edge="1" parent="1" source="concoct" target="dastool">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge13" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;curved=1;" edge="1" parent="1" source="maxbin" target="dastool">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge14" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.67;entryDx=0;entryDy=0;curved=1;entryPerimeter=0;" edge="1" parent="1" source="metabat" target="dastool">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge15" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="dastool" target="bins">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge16" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;curved=1;" edge="1" parent="1" source="dastool" target="unbinned">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- MAG analysis flow -->
+        <mxCell id="edge17" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;curved=1;" edge="1" parent="1" source="bins" target="bakta">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge18" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="bakta" target="phispy-mag">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge19" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.33;entryDx=0;entryDy=0;curved=1;entryPerimeter=0;" edge="1" parent="1" source="bins" target="genomad-mag">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge20" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;curved=1;" edge="1" parent="1" source="phispy-mag" target="merge-mag">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge21" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;curved=1;" edge="1" parent="1" source="genomad-mag" target="merge-mag">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge22" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="merge-mag" target="mag-prophages">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge23" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.67;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;curved=1;exitPerimeter=0;" edge="1" parent="1" source="bins" target="gtdbtk">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge24" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="gtdbtk" target="mag-taxonomy">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- Unbinned analysis flow -->
+        <mxCell id="edge25" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;curved=1;" edge="1" parent="1" source="unbinned" target="genomad-unbinned">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge26" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;curved=1;" edge="1" parent="1" source="unbinned" target="checkv-prophage-pred">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge27" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;curved=1;" edge="1" parent="1" source="genomad-unbinned" target="merge-unbinned">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge28" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;curved=1;" edge="1" parent="1" source="checkv-prophage-pred" target="merge-unbinned">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge29" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="merge-unbinned" target="unbinned-prophages">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge30" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;curved=1;" edge="1" parent="1" source="genomad-unbinned" target="free-phages">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge31" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;curved=1;" edge="1" parent="1" source="unbinned" target="mask-prophages">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge32" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="mask-prophages" target="mmseqs">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge33" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;curved=1;" edge="1" parent="1" source="mmseqs" target="unbinned-taxonomy">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- Quality & Reporting flow -->
+        <mxCell id="edge34" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;curved=1;" edge="1" parent="1" source="bins" target="checkm">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="700" y="265" />
+              <mxPoint x="700" y="160" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="edge35" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;curved=1;" edge="1" parent="1" source="mag-prophages" target="checkv-mag">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="700" y="385" />
+              <mxPoint x="700" y="160" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="edge36" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;curved=1;" edge="1" parent="1" source="unbinned-prophages" target="checkv-unbinned">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="730" y="335" />
+              <mxPoint x="730" y="163" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="edge37" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.67;entryDx=0;entryDy=0;curved=1;entryPerimeter=0;" edge="1" parent="1" source="free-phages" target="checkv-unbinned">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="730" y="335" />
+              <mxPoint x="730" y="172" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="edge38" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;curved=1;" edge="1" parent="1" source="hr-reads" target="coverm">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="-650" y="375" />
+              <mxPoint x="-650" y="480" />
+              <mxPoint x="1150" y="480" />
+              <mxPoint x="1150" y="160" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="edge39" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.1;entryY=0;entryDx=0;entryDy=0;curved=1;entryPerimeter=0;" edge="1" parent="1" source="checkm" target="combine-results">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge40" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.3;entryY=0;entryDx=0;entryDy=0;curved=1;entryPerimeter=0;" edge="1" parent="1" source="checkv-mag" target="combine-results">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge41" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.7;entryY=0;entryDx=0;entryDy=0;curved=1;entryPerimeter=0;" edge="1" parent="1" source="checkv-unbinned" target="combine-results">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge42" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.9;entryY=0;entryDx=0;entryDy=0;curved=1;entryPerimeter=0;" edge="1" parent="1" source="coverm" target="combine-results">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge43" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0;entryDx=0;entryDy=0;curved=1;" edge="1" parent="1" source="mag-taxonomy" target="combine-results">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge44" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;curved=1;" edge="1" parent="1" source="unbinned-taxonomy" target="combine-results">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="740" y="395" />
+              <mxPoint x="740" y="260" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="edge45" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="combine-results" target="final-table">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge46" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="final-table" target="summary-report">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/prophage_workflow_simple.drawio
+++ b/prophage_workflow_simple.drawio
@@ -1,0 +1,147 @@
+<mxfile host="app.diagrams.net" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36" version="28.2.5">
+  <diagram name="Page-1" id="simple_workflow">
+    <mxGraphModel dx="1400" dy="850" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1100" pageHeight="700" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+
+        <!-- Main workflow stages -->
+        <mxCell id="stage1" value="&lt;b&gt;1. Preprocessing&lt;/b&gt;&lt;br&gt;Quality control &amp;amp; host removal&lt;br&gt;&lt;font color=&quot;#666666&quot;&gt;(Fastp, Minimap2)&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontSize=13;align=center;verticalAlign=middle;" vertex="1" parent="1">
+          <mxGeometry x="40" y="60" width="200" height="80" as="geometry" />
+        </mxCell>
+
+        <mxCell id="stage2" value="&lt;b&gt;2. Assembly &amp;amp; Binning&lt;/b&gt;&lt;br&gt;Metagenome assembly &amp;amp; MAG creation&lt;br&gt;&lt;font color=&quot;#666666&quot;&gt;(MEGAHIT, DAS Tool)&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=13;align=center;verticalAlign=middle;" vertex="1" parent="1">
+          <mxGeometry x="280" y="60" width="200" height="80" as="geometry" />
+        </mxCell>
+
+        <!-- Split paths -->
+        <mxCell id="split-label" value="Pipeline splits into two parallel paths:" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontStyle=2;fontSize=12;fontColor=#666666;" vertex="1" parent="1">
+          <mxGeometry x="265" y="160" width="230" height="30" as="geometry" />
+        </mxCell>
+
+        <!-- MAG path -->
+        <mxCell id="mag-box" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;strokeWidth=2;opacity=60;" vertex="1" parent="1">
+          <mxGeometry x="40" y="210" width="220" height="330" as="geometry" />
+        </mxCell>
+
+        <mxCell id="mag-header" value="&lt;b&gt;MAG Analysis&lt;/b&gt;" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontStyle=1;fontSize=14;" vertex="1" parent="1">
+          <mxGeometry x="90" y="220" width="120" height="30" as="geometry" />
+        </mxCell>
+
+        <mxCell id="mag-stage1" value="&lt;b&gt;Prophage Detection&lt;/b&gt;&lt;br&gt;geNomad + PhiSpy" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=11;" vertex="1" parent="1">
+          <mxGeometry x="60" y="260" width="180" height="60" as="geometry" />
+        </mxCell>
+
+        <mxCell id="mag-stage2" value="&lt;b&gt;Taxonomy&lt;/b&gt;&lt;br&gt;GTDB-Tk" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=11;" vertex="1" parent="1">
+          <mxGeometry x="60" y="340" width="180" height="50" as="geometry" />
+        </mxCell>
+
+        <mxCell id="mag-stage3" value="&lt;b&gt;Quality Control&lt;/b&gt;&lt;br&gt;CheckM + CheckV" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=11;" vertex="1" parent="1">
+          <mxGeometry x="60" y="410" width="180" height="50" as="geometry" />
+        </mxCell>
+
+        <mxCell id="mag-output" value="MAG prophages&lt;br&gt;with host taxonomy" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=11;fontStyle=2;" vertex="1" parent="1">
+          <mxGeometry x="60" y="480" width="180" height="45" as="geometry" />
+        </mxCell>
+
+        <!-- Unbinned path -->
+        <mxCell id="unbinned-box" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;strokeWidth=2;opacity=60;" vertex="1" parent="1">
+          <mxGeometry x="300" y="210" width="220" height="330" as="geometry" />
+        </mxCell>
+
+        <mxCell id="unbinned-header" value="&lt;b&gt;Unbinned Contig Analysis&lt;/b&gt;" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontStyle=1;fontSize=14;" vertex="1" parent="1">
+          <mxGeometry x="305" y="220" width="210" height="30" as="geometry" />
+        </mxCell>
+
+        <mxCell id="unbinned-stage1" value="&lt;b&gt;Prophage + Free Phage Detection&lt;/b&gt;&lt;br&gt;geNomad + CheckV" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=11;" vertex="1" parent="1">
+          <mxGeometry x="320" y="260" width="180" height="60" as="geometry" />
+        </mxCell>
+
+        <mxCell id="unbinned-stage2" value="&lt;b&gt;Taxonomy&lt;/b&gt;&lt;br&gt;MMseqs (masked contigs)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=11;" vertex="1" parent="1">
+          <mxGeometry x="320" y="340" width="180" height="50" as="geometry" />
+        </mxCell>
+
+        <mxCell id="unbinned-stage3" value="&lt;b&gt;Quality Control&lt;/b&gt;&lt;br&gt;CheckV" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=11;" vertex="1" parent="1">
+          <mxGeometry x="320" y="410" width="180" height="50" as="geometry" />
+        </mxCell>
+
+        <mxCell id="unbinned-output" value="Unbinned prophages &amp;amp;&lt;br&gt;free phages with taxonomy" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=11;fontStyle=2;" vertex="1" parent="1">
+          <mxGeometry x="320" y="480" width="180" height="45" as="geometry" />
+        </mxCell>
+
+        <!-- Coverage analysis (spans both) -->
+        <mxCell id="coverm-box" value="&lt;b&gt;Coverage Analysis&lt;/b&gt;&lt;br&gt;CoverM mapping to all bins" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f5f5f5;strokeColor=#666666;fontSize=11;dashed=1;dashPattern=5 5;" vertex="1" parent="1">
+          <mxGeometry x="560" y="260" width="180" height="60" as="geometry" />
+        </mxCell>
+
+        <!-- Final output -->
+        <mxCell id="final-stage" value="&lt;b&gt;3. Reporting&lt;/b&gt;&lt;br&gt;Comprehensive prophage table &amp;amp;&lt;br&gt;multi-sample summary report" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=13;align=center;verticalAlign=middle;" vertex="1" parent="1">
+          <mxGeometry x="40" y="580" width="700" height="80" as="geometry" />
+        </mxCell>
+
+        <!-- Arrows -->
+        <mxCell id="arrow1" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;" edge="1" parent="1" source="stage1" target="stage2">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <mxCell id="arrow2" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.25;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;strokeWidth=2;" edge="1" parent="1" source="stage2" target="mag-box">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <mxCell id="arrow3" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.75;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;strokeWidth=2;" edge="1" parent="1" source="stage2" target="unbinned-box">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <mxCell id="arrow4" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="mag-stage1" target="mag-stage2">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <mxCell id="arrow5" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="mag-stage2" target="mag-stage3">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <mxCell id="arrow6" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="mag-stage3" target="mag-output">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <mxCell id="arrow7" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="unbinned-stage1" target="unbinned-stage2">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <mxCell id="arrow8" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="unbinned-stage2" target="unbinned-stage3">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <mxCell id="arrow9" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="unbinned-stage3" target="unbinned-output">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <mxCell id="arrow10" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.25;entryY=0;entryDx=0;entryDy=0;strokeWidth=2;" edge="1" parent="1" source="mag-output" target="final-stage">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <mxCell id="arrow11" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.75;entryY=0;entryDx=0;entryDy=0;strokeWidth=2;" edge="1" parent="1" source="unbinned-output" target="final-stage">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <mxCell id="arrow12" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=1;dashed=1;dashPattern=5 5;" edge="1" parent="1" source="coverm-box" target="mag-stage3">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <mxCell id="arrow13" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=1;dashed=1;dashPattern=5 5;" edge="1" parent="1" source="coverm-box" target="unbinned-stage3">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- Labels for outputs -->
+        <mxCell id="mag-label" value="Binned contigs (MAGs)" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=10;fontColor=#0066CC;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="75" y="165" width="140" height="30" as="geometry" />
+        </mxCell>
+
+        <mxCell id="unbinned-label" value="Unbinned contigs (&gt;4kb)" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=10;fontColor=#B8860B;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="340" y="165" width="150" height="30" as="geometry" />
+        </mxCell>
+
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/updated_workflow_091024.drawio
+++ b/updated_workflow_091024.drawio
@@ -1,0 +1,245 @@
+<mxfile host="app.diagrams.net" agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36" version="24.7.17">
+  <diagram id="C5RBs43oDa-KdzZeNtuy" name="Page-1">
+    <mxGraphModel dx="1877" dy="557" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+      <root>
+        <mxCell id="WIyWlLk6GJQsqaUBKTNV-0" />
+        <mxCell id="WIyWlLk6GJQsqaUBKTNV-1" parent="WIyWlLk6GJQsqaUBKTNV-0" />
+        <mxCell id="BkHxjyn6nh-NbkDj83uh-90" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#f5f5f5;strokeColor=#666666;strokeWidth=0;fontColor=#333333;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-790" y="100" width="930" height="580" as="geometry" />
+        </mxCell>
+        <mxCell id="BkHxjyn6nh-NbkDj83uh-89" value="" style="rounded=0;whiteSpace=wrap;html=1;strokeWidth=0;fillColor=#e1d5e7;strokeColor=#9673a6;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-360" y="100" width="500" height="400" as="geometry" />
+        </mxCell>
+        <mxCell id="BkHxjyn6nh-NbkDj83uh-87" value="" style="rounded=0;whiteSpace=wrap;html=1;strokeWidth=0;fillColor=#d5e8d4;strokeColor=#82b366;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-580" y="100" width="220" height="400" as="geometry" />
+        </mxCell>
+        <mxCell id="BkHxjyn6nh-NbkDj83uh-84" value="" style="rounded=0;whiteSpace=wrap;html=1;strokeWidth=0;fillColor=#ffe6cc;strokeColor=#d79b00;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-790" y="100" width="210" height="400" as="geometry" />
+        </mxCell>
+        <mxCell id="BkHxjyn6nh-NbkDj83uh-55" style="edgeStyle=orthogonalEdgeStyle;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="WIyWlLk6GJQsqaUBKTNV-1" source="WIyWlLk6GJQsqaUBKTNV-3" target="BkHxjyn6nh-NbkDj83uh-23" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="WIyWlLk6GJQsqaUBKTNV-3" value="Raw reads" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;glass=0;strokeWidth=1;shadow=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-730" y="155" width="90" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="BkHxjyn6nh-NbkDj83uh-58" style="edgeStyle=orthogonalEdgeStyle;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" parent="WIyWlLk6GJQsqaUBKTNV-1" source="BkHxjyn6nh-NbkDj83uh-5" target="BkHxjyn6nh-NbkDj83uh-28" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="ANyt7hIjNwJCfM5YAsnE-32" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;curved=1;" parent="WIyWlLk6GJQsqaUBKTNV-1" source="BkHxjyn6nh-NbkDj83uh-5" target="jNMbfG85S6dREh2q5Bs9-10" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="BkHxjyn6nh-NbkDj83uh-5" value="Host-removed reads" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;glass=0;strokeWidth=1;shadow=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-730" y="425" width="90" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="BkHxjyn6nh-NbkDj83uh-98" style="edgeStyle=orthogonalEdgeStyle;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="WIyWlLk6GJQsqaUBKTNV-1" source="BkHxjyn6nh-NbkDj83uh-15" target="BkHxjyn6nh-NbkDj83uh-44" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="BkHxjyn6nh-NbkDj83uh-15" value="Unbinned contigs" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;glass=0;strokeWidth=1;shadow=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-20" y="260" width="90" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="BkHxjyn6nh-NbkDj83uh-56" style="edgeStyle=orthogonalEdgeStyle;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="WIyWlLk6GJQsqaUBKTNV-1" source="BkHxjyn6nh-NbkDj83uh-23" target="BkHxjyn6nh-NbkDj83uh-5" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="BkHxjyn6nh-NbkDj83uh-23" value="Trimmed reads" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;glass=0;strokeWidth=1;shadow=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-730" y="290" width="90" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="BkHxjyn6nh-NbkDj83uh-26" value="&lt;b&gt;Minimap2&lt;/b&gt; to remove reads mapping to host genome" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-770" y="343" width="170" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="BkHxjyn6nh-NbkDj83uh-24" value="&lt;b&gt;Fastp&lt;/b&gt; for adapter removal" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-770" y="208" width="170" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="BkHxjyn6nh-NbkDj83uh-59" style="edgeStyle=orthogonalEdgeStyle;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" parent="WIyWlLk6GJQsqaUBKTNV-1" source="BkHxjyn6nh-NbkDj83uh-28" target="BkHxjyn6nh-NbkDj83uh-39" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="BkHxjyn6nh-NbkDj83uh-28" value="&lt;b&gt;metaSPAdes&lt;/b&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-513" y="355" width="100" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="ANyt7hIjNwJCfM5YAsnE-1" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;curved=1;" parent="WIyWlLk6GJQsqaUBKTNV-1" source="BkHxjyn6nh-NbkDj83uh-30" target="BkHxjyn6nh-NbkDj83uh-41" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="BkHxjyn6nh-NbkDj83uh-30" value="&lt;b&gt;CONCOCT&lt;/b&gt;&lt;span style=&quot;color: rgba(0, 0, 0, 0); font-family: monospace; font-size: 0px; text-align: start; text-wrap: nowrap;&quot;&gt;%3CmxGraphModel%3E%3Croot%3E%3CmxCell%20id%3D%220%22%2F%3E%3CmxCell%20id%3D%221%22%20parent%3D%220%22%2F%3E%3CmxCell%20id%3D%222%22%20value%3D%22remove%20contigs%20%26amp%3Blt%3B%201000bp%22%20style%3D%22ellipse%3BwhiteSpace%3Dwrap%3Bhtml%3D1%3BfillColor%3D%23fff2cc%3BstrokeColor%3D%23d6b656%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%3CmxGeometry%20x%3D%2270%22%20y%3D%22400%22%20width%3D%22100%22%20height%3D%2260%22%20as%3D%22geometry%22%2F%3E%3C%2FmxCell%3E%3C%2Froot%3E%3C%2FmxGraphModel%3E&lt;/span&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-320" y="105" width="100" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="ANyt7hIjNwJCfM5YAsnE-30" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="WIyWlLk6GJQsqaUBKTNV-1" source="BkHxjyn6nh-NbkDj83uh-31" target="ANyt7hIjNwJCfM5YAsnE-26" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="BkHxjyn6nh-NbkDj83uh-31" value="&lt;b&gt;checkM&lt;/b&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-110" y="520" width="103" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="ANyt7hIjNwJCfM5YAsnE-2" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="WIyWlLk6GJQsqaUBKTNV-1" source="BkHxjyn6nh-NbkDj83uh-33" target="BkHxjyn6nh-NbkDj83uh-41" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="BkHxjyn6nh-NbkDj83uh-33" value="&lt;b&gt;MaxBin2&lt;/b&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-320" y="165" width="100" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="BkHxjyn6nh-NbkDj83uh-38" style="edgeStyle=orthogonalEdgeStyle;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" parent="WIyWlLk6GJQsqaUBKTNV-1" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="-490" y="395" as="sourcePoint" />
+            <mxPoint x="-490" y="395" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="jNMbfG85S6dREh2q5Bs9-3" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" parent="WIyWlLk6GJQsqaUBKTNV-1" source="BkHxjyn6nh-NbkDj83uh-39" target="BkHxjyn6nh-NbkDj83uh-40" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="BkHxjyn6nh-NbkDj83uh-39" value="Contigs" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;glass=0;strokeWidth=1;shadow=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-508" y="300" width="90" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="jNMbfG85S6dREh2q5Bs9-4" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;curved=1;" parent="WIyWlLk6GJQsqaUBKTNV-1" source="BkHxjyn6nh-NbkDj83uh-40" target="BkHxjyn6nh-NbkDj83uh-33" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="jNMbfG85S6dREh2q5Bs9-5" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;curved=1;" parent="WIyWlLk6GJQsqaUBKTNV-1" source="BkHxjyn6nh-NbkDj83uh-40" target="BkHxjyn6nh-NbkDj83uh-30" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="jNMbfG85S6dREh2q5Bs9-6" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;curved=1;" parent="WIyWlLk6GJQsqaUBKTNV-1" source="BkHxjyn6nh-NbkDj83uh-40" target="BkHxjyn6nh-NbkDj83uh-53" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="BkHxjyn6nh-NbkDj83uh-40" value="Contigs &amp;gt;1000bp" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;glass=0;strokeWidth=1;shadow=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-508" y="155" width="90" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="ANyt7hIjNwJCfM5YAsnE-4" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;curved=1;" parent="WIyWlLk6GJQsqaUBKTNV-1" source="BkHxjyn6nh-NbkDj83uh-41" target="BkHxjyn6nh-NbkDj83uh-77" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="ANyt7hIjNwJCfM5YAsnE-5" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;curved=1;" parent="WIyWlLk6GJQsqaUBKTNV-1" source="BkHxjyn6nh-NbkDj83uh-41" target="BkHxjyn6nh-NbkDj83uh-15" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="BkHxjyn6nh-NbkDj83uh-41" value="&lt;b&gt;DAS Tool&lt;/b&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-80" y="165" width="100" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="ANyt7hIjNwJCfM5YAsnE-10" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;curved=1;" parent="WIyWlLk6GJQsqaUBKTNV-1" source="BkHxjyn6nh-NbkDj83uh-44" target="ANyt7hIjNwJCfM5YAsnE-8" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="BkHxjyn6nh-NbkDj83uh-44" value="Unbinned contigs &amp;gt;4000bp" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;glass=0;strokeWidth=1;shadow=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-25" y="395" width="100" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="BkHxjyn6nh-NbkDj83uh-48" value="remove contigs &amp;lt; 4000bp" style="ellipse;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-20" y="320" width="90" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="ANyt7hIjNwJCfM5YAsnE-3" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;curved=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="WIyWlLk6GJQsqaUBKTNV-1" source="BkHxjyn6nh-NbkDj83uh-53" target="BkHxjyn6nh-NbkDj83uh-41" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="-150" y="240" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="BkHxjyn6nh-NbkDj83uh-53" value="&lt;b&gt;MetaBat2&lt;/b&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-320" y="225" width="100" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="BkHxjyn6nh-NbkDj83uh-73" value="Bins" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;glass=0;strokeWidth=1;shadow=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-200" y="115" width="30" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="BkHxjyn6nh-NbkDj83uh-75" value="Bins" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;glass=0;strokeWidth=1;shadow=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-200" y="175" width="30" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="BkHxjyn6nh-NbkDj83uh-76" value="Bins" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;glass=0;strokeWidth=1;shadow=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-200" y="235" width="30" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="ANyt7hIjNwJCfM5YAsnE-9" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;curved=1;" parent="WIyWlLk6GJQsqaUBKTNV-1" source="BkHxjyn6nh-NbkDj83uh-77" target="ANyt7hIjNwJCfM5YAsnE-8" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="BkHxjyn6nh-NbkDj83uh-77" value="Non-redundant set of bins" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;glass=0;strokeWidth=1;shadow=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-130" y="260" width="90" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="BkHxjyn6nh-NbkDj83uh-91" value="Preprocessing" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontStyle=1;fontSize=15;fontFamily=Helvetica;textShadow=1;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-790" y="100" width="120" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="BkHxjyn6nh-NbkDj83uh-92" value="Assembly" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontStyle=1;fontSize=15;textShadow=1;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-510" y="100" width="90" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="BkHxjyn6nh-NbkDj83uh-94" value="Binning" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontStyle=1;fontSize=15;textShadow=1;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="70" y="100" width="70" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="o28xDe-LV78tvLijXnbG-39" style="edgeStyle=orthogonalEdgeStyle;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="WIyWlLk6GJQsqaUBKTNV-1" source="o28xDe-LV78tvLijXnbG-3" target="o28xDe-LV78tvLijXnbG-5" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="o28xDe-LV78tvLijXnbG-3" value="&lt;b&gt;geNomad&lt;/b&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-390" y="520" width="100" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="o28xDe-LV78tvLijXnbG-40" style="edgeStyle=orthogonalEdgeStyle;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="WIyWlLk6GJQsqaUBKTNV-1" source="o28xDe-LV78tvLijXnbG-4" target="o28xDe-LV78tvLijXnbG-5" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="o28xDe-LV78tvLijXnbG-4" value="&lt;b&gt;phiSpy&lt;/b&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-250" y="520" width="100" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="ANyt7hIjNwJCfM5YAsnE-20" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;curved=1;" parent="WIyWlLk6GJQsqaUBKTNV-1" source="o28xDe-LV78tvLijXnbG-5" target="ANyt7hIjNwJCfM5YAsnE-19" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="o28xDe-LV78tvLijXnbG-5" value="Predicted prophages" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;glass=0;strokeWidth=1;shadow=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-315" y="625" width="90" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="o28xDe-LV78tvLijXnbG-15" value="" style="ellipse;whiteSpace=wrap;html=1;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-135" y="590" width="5" as="geometry" />
+        </mxCell>
+        <mxCell id="ANyt7hIjNwJCfM5YAsnE-23" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="WIyWlLk6GJQsqaUBKTNV-1" source="KcQ7Xz1-UsJmnDCyzrMH-3" target="ANyt7hIjNwJCfM5YAsnE-14" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="KcQ7Xz1-UsJmnDCyzrMH-3" value="&lt;b&gt;CAT&lt;/b&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-550" y="520" width="100" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="BkHxjyn6nh-NbkDj83uh-34" value="remove contigs &amp;lt; 1000bp" style="ellipse;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-508" y="225" width="90" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="ANyt7hIjNwJCfM5YAsnE-25" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="WIyWlLk6GJQsqaUBKTNV-1" source="jNMbfG85S6dREh2q5Bs9-10" target="ANyt7hIjNwJCfM5YAsnE-24" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="jNMbfG85S6dREh2q5Bs9-10" value="&lt;b&gt;CoverM&lt;/b&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-710" y="520" width="100" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="ANyt7hIjNwJCfM5YAsnE-13" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;curved=1;" parent="WIyWlLk6GJQsqaUBKTNV-1" source="ANyt7hIjNwJCfM5YAsnE-8" target="KcQ7Xz1-UsJmnDCyzrMH-3" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="-270" y="500" />
+              <mxPoint x="-500" y="500" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="ANyt7hIjNwJCfM5YAsnE-15" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;curved=1;" parent="WIyWlLk6GJQsqaUBKTNV-1" source="ANyt7hIjNwJCfM5YAsnE-8" target="BkHxjyn6nh-NbkDj83uh-31" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="ANyt7hIjNwJCfM5YAsnE-16" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;curved=1;" parent="WIyWlLk6GJQsqaUBKTNV-1" source="ANyt7hIjNwJCfM5YAsnE-8" target="jNMbfG85S6dREh2q5Bs9-10" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="-270" y="490" />
+              <mxPoint x="-660" y="490" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="ANyt7hIjNwJCfM5YAsnE-21" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;curved=1;" parent="WIyWlLk6GJQsqaUBKTNV-1" source="ANyt7hIjNwJCfM5YAsnE-8" target="o28xDe-LV78tvLijXnbG-3" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="-270" y="500" />
+              <mxPoint x="-340" y="500" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="ANyt7hIjNwJCfM5YAsnE-22" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;curved=1;" parent="WIyWlLk6GJQsqaUBKTNV-1" source="ANyt7hIjNwJCfM5YAsnE-8" target="o28xDe-LV78tvLijXnbG-4" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="-270" y="500" />
+              <mxPoint x="-200" y="500" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="ANyt7hIjNwJCfM5YAsnE-8" value="Bins and contigs" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;glass=0;strokeWidth=1;shadow=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-315" y="395" width="90" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="ANyt7hIjNwJCfM5YAsnE-14" value="Taxonomy prediction" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;glass=0;strokeWidth=1;shadow=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-545" y="625" width="90" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="ANyt7hIjNwJCfM5YAsnE-31" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="WIyWlLk6GJQsqaUBKTNV-1" source="ANyt7hIjNwJCfM5YAsnE-19" target="ANyt7hIjNwJCfM5YAsnE-28" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="ANyt7hIjNwJCfM5YAsnE-19" value="&lt;b&gt;checkV&lt;/b&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-110" y="620" width="103" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="ANyt7hIjNwJCfM5YAsnE-24" value="Read coverage" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;glass=0;strokeWidth=1;shadow=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="-705" y="625" width="90" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="ANyt7hIjNwJCfM5YAsnE-26" value="Bacterial genome quality scores" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;glass=0;strokeWidth=1;shadow=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="20" y="530" width="100" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="ANyt7hIjNwJCfM5YAsnE-28" value="Prophage quality scores" style="rounded=1;whiteSpace=wrap;html=1;fontSize=12;glass=0;strokeWidth=1;shadow=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" parent="WIyWlLk6GJQsqaUBKTNV-1" vertex="1">
+          <mxGeometry x="20" y="630" width="100" height="30" as="geometry" />
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -43,10 +43,10 @@ def detect_fastq_pattern(reads_dir):
 if config.get("fastq_names_1", "auto") == "auto":
     r1_pattern, r2_pattern, SAMPLES = detect_fastq_pattern(config["reads"])
     if not SAMPLES:
+        reads_dir = config['reads']
         raise ValueError(
-            f"Could not auto-detect FASTQ files in '{config['reads']}'. "
-            f"Tried patterns: {[p[0] for p in COMMON_PATTERNS]}. "
-            f"Set 'fastq_names_1' and 'fastq_names_2' in config to specify custom patterns."
+            "Could not auto-detect FASTQ files in '" + reads_dir + "'. "
+            "Set 'fastq_names_1' and 'fastq_names_2' in config to specify custom patterns."
         )
     config["fastq_names_1"] = r1_pattern
     config["fastq_names_2"] = r2_pattern

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -2,9 +2,56 @@ from snakemake.utils import min_version
 min_version("8.0")
 
 import os
+import glob
 
 configfile: "../config/config.yaml"
-SAMPLES, = glob_wildcards(os.path.join(config["reads"],config["fastq_names_1"]))
+
+# Common paired-end FASTQ naming patterns
+COMMON_PATTERNS = [
+    ("{sample}_1.fastq.gz", "{sample}_2.fastq.gz"),
+    ("{sample}_R1.fastq.gz", "{sample}_R2.fastq.gz"),
+    ("{sample}_R1_001.fastq.gz", "{sample}_R2_001.fastq.gz"),  # Illumina default
+    ("{sample}_1.fq.gz", "{sample}_2.fq.gz"),
+    ("{sample}_R1.fq.gz", "{sample}_R2.fq.gz"),
+    ("{sample}_R1_001.fq.gz", "{sample}_R2_001.fq.gz"),
+    ("{sample}_1.fastq", "{sample}_2.fastq"),
+    ("{sample}_R1.fastq", "{sample}_R2.fastq"),
+    ("{sample}_R1_001.fastq", "{sample}_R2_001.fastq"),
+    ("{sample}_1.fq", "{sample}_2.fq"),
+    ("{sample}_R1.fq", "{sample}_R2.fq"),
+    ("{sample}_R1_001.fq", "{sample}_R2_001.fq"),
+]
+
+def detect_fastq_pattern(reads_dir):
+    """
+    Auto-detect paired-end FASTQ naming pattern by probing for common suffixes.
+    Returns (r1_pattern, r2_pattern, samples) tuple.
+    """
+    for r1_pattern, r2_pattern in COMMON_PATTERNS:
+        # Convert pattern to glob: {sample} -> *
+        glob_pattern = os.path.join(reads_dir, r1_pattern.replace("{sample}", "*"))
+        matches = glob.glob(glob_pattern)
+        if matches:
+            # Found files - verify we can extract samples
+            samples, = glob_wildcards(os.path.join(reads_dir, r1_pattern))
+            if samples:
+                print(f"Auto-detected FASTQ pattern: {r1_pattern} / {r2_pattern}")
+                return r1_pattern, r2_pattern, samples
+    return None, None, []
+
+# Determine FASTQ patterns - auto-detect or use explicit config
+if config.get("fastq_names_1", "auto") == "auto":
+    r1_pattern, r2_pattern, SAMPLES = detect_fastq_pattern(config["reads"])
+    if not SAMPLES:
+        raise ValueError(
+            f"Could not auto-detect FASTQ files in '{config['reads']}'. "
+            f"Tried patterns: {[p[0] for p in COMMON_PATTERNS]}. "
+            f"Set 'fastq_names_1' and 'fastq_names_2' in config to specify custom patterns."
+        )
+    config["fastq_names_1"] = r1_pattern
+    config["fastq_names_2"] = r2_pattern
+else:
+    SAMPLES, = glob_wildcards(os.path.join(config["reads"], config["fastq_names_1"]))
 
 include: "rules/preprocessing.smk"
 include: "rules/assembly.smk"


### PR DESCRIPTION
## Summary
- Pipeline now automatically detects common FASTQ naming patterns (`_1/_2`, `_R1/_R2`, `_R1_001/_R2_001`) with `.fastq.gz`, `.fq.gz`, `.fastq`, and `.fq` extensions
- Users no longer need to configure `fastq_names_1` and `fastq_names_2` for standard naming conventions
- Explicit pattern configuration still available for non-standard naming

## Test plan
- [x] Tested with `_R1.fastq.gz` / `_R2.fastq.gz` pattern (dry-run successful, 11 samples)
- [x] Tested with `_R1_001.fastq.gz` / `_R2_001.fastq.gz` Illumina pattern
- [x] Tested with `_1.fastq.gz` / `_2.fastq.gz` pattern
- [x] Backward compatible - explicit config patterns still work

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)