### PR TITLE
Batch MMseqs taxonomy across samples to reduce memory overhead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ genomad/
 *_IMPLEMENTATION.md
 *_CHECKLIST.md
 *_BRANCH.md
+
+# Test directories
+workflow/test_mmseqs_batch/

--- a/workflow/rules/prophage_unbinned.smk
+++ b/workflow/rules/prophage_unbinned.smk
@@ -186,7 +186,7 @@ rule extract_free_phages:
 
 rule mask_prophage_regions:
     input:
-        contigs = os.path.join(config["outdir"], "{sample}", "binning", "filt_4000_seqs_to_keep.fasta"),
+        contigs = os.path.join(config["outdir"], "{sample}", "phage_analysis", "unbinned", "unbinned_contigs.fasta"),
         prophage_bed = os.path.join(config["outdir"], "{sample}", "phage_analysis", "unbinned", "genomad_prophages.bed")
     conda: config["conda_envs"]["phage_all"]
     output:
@@ -202,9 +202,20 @@ rule mask_prophage_regions:
             n_regions=$(wc -l < {input.prophage_bed})
             echo "Masking $n_regions prophage regions" > {output.mask_stats}
 
-            # Convert BED to proper format for bedtools
-            # BED columns: contig start end, need to add NODE_ prefix
-            awk '{{print "NODE_" $1 "\t" $2 "\t" $3}}' {input.prophage_bed} > {config[outdir]}/{wildcards.sample}/phage_analysis/unbinned/mask_regions.bed
+            # Build lookup table: contig_number -> full_contig_name
+            # FASTA headers have sample prefix, e.g., SAMPLE_NODE_1215_length_95187_cov_12.9194
+            grep "^>" {input.contigs} | sed 's/>//' | awk -F'_NODE_' '{{
+                split($2, parts, "_")
+                contig_num = parts[1]
+                print contig_num "\t" $0
+            }}' > {config[outdir]}/{wildcards.sample}/phage_analysis/unbinned/contig_lookup.tsv
+
+            # Convert BED to proper format for bedtools using full contig names
+            # BED input columns: contig_num start end ...
+            # Output: full_contig_name start end
+            awk 'NR==FNR {{lookup[$1]=$2; next}} $1 in lookup {{print lookup[$1] "\t" $2 "\t" $3}}' \
+                {config[outdir]}/{wildcards.sample}/phage_analysis/unbinned/contig_lookup.tsv \
+                {input.prophage_bed} > {config[outdir]}/{wildcards.sample}/phage_analysis/unbinned/mask_regions.bed
 
             # Use bedtools maskfasta to mask regions with N's
             bedtools maskfasta -fi {input.contigs} -bed {config[outdir]}/{wildcards.sample}/phage_analysis/unbinned/mask_regions.bed -fo {output.masked_contigs} 2>> {log}

--- a/workflow/rules/taxonomy.smk
+++ b/workflow/rules/taxonomy.smk
@@ -1,103 +1,167 @@
 
+# =============================================================================
+# MMseqs Taxonomy - Batched across all samples
+# =============================================================================
+# To reduce memory overhead, we combine contigs from all samples, run MMseqs
+# once, then split results back to per-sample directories.
+# This reduces N × 700GB jobs to 1 × 700GB job.
+# =============================================================================
+
 # Rule priority based on configuration
 if config.get("taxonomy_scope", "prophage_only") == "all_contigs":
-    ruleorder: mmseqs_taxonomy_all_contigs > mmseqs_taxonomy_prophage_only
+    ruleorder: combine_contigs_for_mmseqs_all > combine_contigs_for_mmseqs_prophage_only
 else:
-    ruleorder: mmseqs_taxonomy_prophage_only > mmseqs_taxonomy_all_contigs
+    ruleorder: combine_contigs_for_mmseqs_prophage_only > combine_contigs_for_mmseqs_all
 
-rule mmseqs_taxonomy_all_contigs:
+
+# -----------------------------------------------------------------------------
+# Step 1a: Prepare and combine contigs (prophage_only mode)
+# -----------------------------------------------------------------------------
+rule combine_contigs_for_mmseqs_prophage_only:
     input:
-        contigs = os.path.join(config["outdir"], "{sample}", "binning", "final_filtered_contigs.fasta"),
-        masked_unbinned = os.path.join(config["outdir"], "{sample}", "phage_analysis", "unbinned", "masked_contigs.fasta")
-    params:
-        db = config["mmseqs_database"]
-    threads: 24
-    conda: config["conda_envs"]["mmseqs"]
+        masked_contigs = expand(
+            os.path.join(config["outdir"], "{sample}", "phage_analysis", "unbinned", "masked_contigs.fasta"),
+            sample=SAMPLES
+        ),
+        prophage_tables = expand(
+            os.path.join(config["outdir"], "{sample}", "phage_analysis", "final_prophage_table.tsv"),
+            sample=SAMPLES
+        )
     output:
-        directory(os.path.join(config["outdir"], "{sample}", "taxonomy", "mmseqs"))
+        combined = os.path.join(config["outdir"], "taxonomy", "mmseqs_combined", "combined_contigs.fasta"),
+        sample_list = os.path.join(config["outdir"], "taxonomy", "mmseqs_combined", "samples.txt")
+    params:
+        samples = SAMPLES,
+        outdir = config["outdir"]
     log:
-        os.path.join(config["outdir"], "logs", "mmseqs", "{sample}.log")
-    benchmark:
-        os.path.join(config["outdir"], "benchmarks", "mmseqs", "{sample}_bmrk.txt")
+        os.path.join(config["outdir"], "logs", "mmseqs", "combine_contigs.log")
+    conda: config["conda_envs"]["phage_all"]
     shell:
         """
         set -ue
-        mkdir -p {output}
+        mkdir -p $(dirname {output.combined})
 
-        echo "Running taxonomy on masked unbinned contigs (comprehensive mode)" > {log}
-        cp {input.masked_unbinned} {output}/contigs_for_taxonomy.fasta
+        echo "Combining prophage-containing contigs from all samples (prophage_only mode)" > {log}
 
-        # Create temporary directory
-        TMP_DIR=$(mktemp -d)
+        # Clear output files
+        > {output.combined}
+        > {output.sample_list}
 
-        # Run mmseqs easy-taxonomy (matches phage-analysis pipeline for better performance)
-        mmseqs easy-taxonomy {output}/contigs_for_taxonomy.fasta {params.db} \
-            {output}/contig {output}/tmp \
-            --min-length 30 \
-            -e 1e-15 \
-            --search-type 2 \
-            -s 4.0 \
-            --shuffle 0 \
-            --lca-mode 2 \
-            -a \
-            --tax-lineage 2 \
-            --threads {threads} \
-            --split-mode 0 \
-            --orf-filter 1 \
-            >> {log} 2>&1
+        # Process each sample
+        for sample in {params.samples}; do
+            echo "$sample" >> {output.sample_list}
 
-        # Rename output to match expected filename
-        if [ -f {output}/contig_lca.tsv ]; then
-            mv {output}/contig_lca.tsv {output}/contig.taxonomy
-        else
-            echo "Warning: mmseqs did not produce expected output" >> {log}
-            touch {output}/contig.taxonomy
-        fi
+            masked_file="{params.outdir}/$sample/phage_analysis/unbinned/masked_contigs.fasta"
+            prophage_table="{params.outdir}/$sample/phage_analysis/final_prophage_table.tsv"
 
-        # Clean up temporary files
-        rm -rf {output}/tmp $TMP_DIR
+            # Extract list of unbinned prophage-containing contigs (bin == "none")
+            awk 'NR>1 && $5=="none" {{print "NODE_" $1 "_"}}' "$prophage_table" | sort -u > /tmp/${{sample}}_prophage_contigs.txt
+
+            # Check if there are any prophage contigs
+            if [ -s /tmp/${{sample}}_prophage_contigs.txt ]; then
+                # Extract matching contigs and add sample prefix to headers
+                seqkit grep -r -f /tmp/${{sample}}_prophage_contigs.txt "$masked_file" 2>> {log} | \
+                    sed "s/^>/>${{sample}}__/" >> {output.combined}
+
+                n_contigs=$(grep -c "^>" /tmp/${{sample}}_prophage_contigs.txt || echo 0)
+                echo "  $sample: $n_contigs prophage-containing contigs" >> {log}
+            else
+                echo "  $sample: no prophage-containing contigs" >> {log}
+            fi
+
+            rm -f /tmp/${{sample}}_prophage_contigs.txt
+        done
+
+        total=$(grep -c "^>" {output.combined} || echo 0)
+        echo "Total combined contigs: $total" >> {log}
         """
 
-rule mmseqs_taxonomy_prophage_only:
+
+# -----------------------------------------------------------------------------
+# Step 1b: Prepare and combine contigs (all_contigs mode)
+# -----------------------------------------------------------------------------
+rule combine_contigs_for_mmseqs_all:
     input:
-        masked_unbinned = os.path.join(config["outdir"], "{sample}", "phage_analysis", "unbinned", "masked_contigs.fasta"),
-        prophage_table = os.path.join(config["outdir"], "{sample}", "phage_analysis", "final_prophage_table.tsv")
-    params:
-        db = config["mmseqs_database"]
-    threads: 24
-    conda: config["conda_envs"]["mmseqs"]
+        masked_contigs = expand(
+            os.path.join(config["outdir"], "{sample}", "phage_analysis", "unbinned", "masked_contigs.fasta"),
+            sample=SAMPLES
+        )
     output:
-        directory(os.path.join(config["outdir"], "{sample}", "taxonomy", "mmseqs"))
+        combined = os.path.join(config["outdir"], "taxonomy", "mmseqs_combined", "combined_contigs.fasta"),
+        sample_list = os.path.join(config["outdir"], "taxonomy", "mmseqs_combined", "samples.txt")
+    params:
+        samples = SAMPLES,
+        outdir = config["outdir"]
     log:
-        os.path.join(config["outdir"], "logs", "mmseqs", "{sample}.log")
-    benchmark:
-        os.path.join(config["outdir"], "benchmarks", "mmseqs", "{sample}_bmrk.txt")
+        os.path.join(config["outdir"], "logs", "mmseqs", "combine_contigs.log")
     shell:
         """
         set -ue
-        mkdir -p {output}
+        mkdir -p $(dirname {output.combined})
 
-        echo "Running taxonomy on masked prophage-containing contigs only (targeted mode)" > {log}
+        echo "Combining all masked contigs from all samples (all_contigs mode)" > {log}
 
-        # Extract list of unbinned prophage-containing contigs (bin == "none")
-        awk 'NR>1 && $5=="none" {{print "NODE_" $1 "_"}}' {input.prophage_table} | sort -u > {output}/prophage_contigs.txt
+        # Clear output files
+        > {output.combined}
+        > {output.sample_list}
 
-        # Extract only unbinned prophage-containing contigs from masked contigs
-        seqkit grep -r -f {output}/prophage_contigs.txt {input.masked_unbinned} > {output}/contigs_for_taxonomy.fasta 2>> {log}
-        
-        # Check if any contigs were extracted
-        if [ ! -s {output}/contigs_for_taxonomy.fasta ]; then
-            echo "No prophage-containing contigs found" >> {log}
-            touch {output}/contig.taxonomy
+        # Process each sample
+        for sample in {params.samples}; do
+            echo "$sample" >> {output.sample_list}
+
+            masked_file="{params.outdir}/$sample/phage_analysis/unbinned/masked_contigs.fasta"
+
+            if [ -s "$masked_file" ]; then
+                # Add sample prefix to headers and append
+                sed "s/^>/>${{sample}}__/" "$masked_file" >> {output.combined}
+
+                n_contigs=$(grep -c "^>" "$masked_file" || echo 0)
+                echo "  $sample: $n_contigs contigs" >> {log}
+            else
+                echo "  $sample: no contigs" >> {log}
+            fi
+        done
+
+        total=$(grep -c "^>" {output.combined} || echo 0)
+        echo "Total combined contigs: $total" >> {log}
+        """
+
+
+# -----------------------------------------------------------------------------
+# Step 2: Run MMseqs on combined contigs (single job for all samples)
+# -----------------------------------------------------------------------------
+rule mmseqs_taxonomy_combined:
+    input:
+        combined = os.path.join(config["outdir"], "taxonomy", "mmseqs_combined", "combined_contigs.fasta")
+    output:
+        taxonomy = os.path.join(config["outdir"], "taxonomy", "mmseqs_combined", "combined.taxonomy"),
+        done = os.path.join(config["outdir"], "taxonomy", "mmseqs_combined", "mmseqs.done")
+    params:
+        db = config["mmseqs_database"],
+        outdir = os.path.join(config["outdir"], "taxonomy", "mmseqs_combined")
+    threads: 24
+    conda: config["conda_envs"]["mmseqs"]
+    log:
+        os.path.join(config["outdir"], "logs", "mmseqs", "combined_taxonomy.log")
+    benchmark:
+        os.path.join(config["outdir"], "benchmarks", "mmseqs", "combined_taxonomy_bmrk.txt")
+    shell:
+        """
+        set -ue
+
+        echo "Running MMseqs taxonomy on combined contigs from all samples" > {log}
+
+        # Check if there are any contigs to process
+        if [ ! -s {input.combined} ]; then
+            echo "No contigs to process" >> {log}
+            touch {output.taxonomy}
+            touch {output.done}
             exit 0
         fi
 
-        # Create temporary directory
-        TMP_DIR=$(mktemp -d)
-
-        # Run mmseqs easy-taxonomy (matches phage-analysis pipeline for better performance)
-        mmseqs easy-taxonomy {output}/contigs_for_taxonomy.fasta {params.db} \
-            {output}/contig {output}/tmp \
+        # Run mmseqs easy-taxonomy
+        mmseqs easy-taxonomy {input.combined} {params.db} \
+            {params.outdir}/contig {params.outdir}/tmp \
             --min-length 30 \
             -e 1e-15 \
             --search-type 2 \
@@ -111,16 +175,51 @@ rule mmseqs_taxonomy_prophage_only:
             --orf-filter 1 \
             >> {log} 2>&1
 
-        # Rename output to match expected filename
-        if [ -f {output}/contig_lca.tsv ]; then
-            mv {output}/contig_lca.tsv {output}/contig.taxonomy
+        # Rename output to final filename
+        if [ -f {params.outdir}/contig_lca.tsv ]; then
+            mv {params.outdir}/contig_lca.tsv {output.taxonomy}
         else
             echo "Warning: mmseqs did not produce expected output" >> {log}
-            touch {output}/contig.taxonomy
+            touch {output.taxonomy}
         fi
 
         # Clean up temporary files
-        rm -rf {output}/tmp $TMP_DIR
+        rm -rf {params.outdir}/tmp
+
+        touch {output.done}
+        """
+
+
+# -----------------------------------------------------------------------------
+# Step 3: Split combined results back to per-sample directories
+# -----------------------------------------------------------------------------
+rule split_mmseqs_taxonomy_results:
+    input:
+        taxonomy = os.path.join(config["outdir"], "taxonomy", "mmseqs_combined", "combined.taxonomy"),
+        done = os.path.join(config["outdir"], "taxonomy", "mmseqs_combined", "mmseqs.done")
+    output:
+        directory(os.path.join(config["outdir"], "{sample}", "taxonomy", "mmseqs"))
+    params:
+        sample = "{sample}"
+    log:
+        os.path.join(config["outdir"], "logs", "mmseqs", "{sample}_split.log")
+    shell:
+        """
+        set -ue
+        mkdir -p {output}
+
+        echo "Extracting taxonomy results for sample: {params.sample}" > {log}
+
+        # Extract lines for this sample (header starts with SAMPLE__)
+        # Remove the sample prefix from contig names in output
+        grep "^{params.sample}__" {input.taxonomy} 2>/dev/null | \
+            sed "s/^{params.sample}__//" > {output}/contig.taxonomy || true
+
+        n_results=$(wc -l < {output}/contig.taxonomy || echo 0)
+        echo "Extracted $n_results taxonomy assignments" >> {log}
+
+        # Ensure file exists even if empty
+        touch {output}/contig.taxonomy
         """
 
 rule gtdbtk_classify_bins:


### PR DESCRIPTION
## Summary

- **Batch MMseqs taxonomy:** Instead of running MMseqs separately for each sample (N × 700GB jobs), contigs from all samples are now combined, MMseqs runs once, then results are split back to per-sample directories. This reduces memory overhead to a single 700GB job.

- **Fix `mask_prophage_regions`:** Changed input from `filt_4000_seqs_to_keep.fasta` to `unbinned_contigs.fasta` and fixed contig name matching by building a lookup table to map contig numbers to full contig names (which include sample prefixes).

## Test plan

- [x] Verified `combined_contigs.fasta` has sample prefixes in headers
- [x] Verified per-sample `contig.taxonomy` files have prefixes stripped
- [x] Verified line counts across all per-sample files sum to `combined.taxonomy`
- [x] Verified `mask_regions.bed` has full contig names
- [x] Verified `contig_lookup.tsv` maps contig numbers to full names
- [x] Verified `masked_contigs.fasta` contains N's in prophage regions

🤖 Generated with [Claude Code](https://claude.com/claude-code)